### PR TITLE
Exclude SENSOR_HEARTRATE for SDK 3.2+

### DIFF
--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -1,0 +1,3 @@
+<properties>
+    <property id="excludeExternalHR" type="boolean">false</property>
+</properties>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -1,0 +1,5 @@
+<settings>
+    <setting propertyKey="@Properties.excludeExternalHR" title="@Strings.excludeExternalHRTitle">
+        <settingConfig type="boolean" />
+    </setting>
+</settings>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -5,4 +5,8 @@
 
     <string id="menu_label_1">Item 1</string>
     <string id="menu_label_2">Item 2</string>
+
+    <string id="settingsTitle">Settings</string>
+    <string id="excludeExternalHRTitle">Exclude External HR</string>
+    <string id="excludeExternalHRDescription">Disable external heart rate sensor (SENSOR_HEARTRATE) and use only onboard sensor for SDK 3.2+</string>
 </strings>

--- a/source/QZCompanionGarminView.mc
+++ b/source/QZCompanionGarminView.mc
@@ -35,12 +35,20 @@ class QZCompanionGarminView extends WatchUi.View {
     function initialize() {
         View.initialize();
         var deviceSettings = System.getDeviceSettings().monkeyVersion;
+        var excludeExternalHR = Application.Properties.getValue("excludeExternalHR");
 
         // Now you can use apiLevel as needed
         System.println("API Level: " + deviceSettings);
+        System.println("Exclude External HR: " + excludeExternalHR);
 
         if((deviceSettings[0] == 3 && deviceSettings[1] >= 2) || deviceSettings[0] > 3) {
-            Sensor.setEnabledSensors( [Sensor.SENSOR_ONBOARD_HEARTRATE, Sensor.SENSOR_HEARTRATE, Sensor.SENSOR_FOOTPOD, Sensor.SENSOR_BIKEPOWER, Sensor.SENSOR_BIKECADENCE, Sensor.SENSOR_BIKESPEED] );
+            if(excludeExternalHR) {
+                // Exclude external HR sensor (SENSOR_HEARTRATE), use only onboard
+                Sensor.setEnabledSensors( [Sensor.SENSOR_ONBOARD_HEARTRATE, Sensor.SENSOR_FOOTPOD, Sensor.SENSOR_BIKEPOWER, Sensor.SENSOR_BIKECADENCE, Sensor.SENSOR_BIKESPEED] );
+            } else {
+                // Include both onboard and external HR sensors
+                Sensor.setEnabledSensors( [Sensor.SENSOR_ONBOARD_HEARTRATE, Sensor.SENSOR_HEARTRATE, Sensor.SENSOR_FOOTPOD, Sensor.SENSOR_BIKEPOWER, Sensor.SENSOR_BIKECADENCE, Sensor.SENSOR_BIKESPEED] );
+            }
         } else {
             Sensor.setEnabledSensors( [Sensor.SENSOR_HEARTRATE, Sensor.SENSOR_FOOTPOD, Sensor.SENSOR_BIKEPOWER, Sensor.SENSOR_BIKECADENCE, Sensor.SENSOR_BIKESPEED] );
         }
@@ -48,7 +56,7 @@ class QZCompanionGarminView extends WatchUi.View {
 
         timer = new Timer.Timer();
         timer.start(method(:tick), 1000, true);
-        Communications.registerForPhoneAppMessages(method(:phoneMessageCallback));        
+        Communications.registerForPhoneAppMessages(method(:phoneMessageCallback));
     }
 
     // Load your resources here


### PR DESCRIPTION
- Created properties.xml with excludeExternalHR boolean property (default: false)
- Created settings.xml UI for the new setting
- Updated strings.xml with setting titles and descriptions
- Modified QZCompanionGarminView.mc to read the property and conditionally enable/disable SENSOR_HEARTRATE
- For SDK 3.2+: when enabled, only SENSOR_ONBOARD_HEARTRATE is used (SENSOR_HEARTRATE excluded)
- For SDK < 3.2: always uses SENSOR_HEARTRATE (onboard not available)